### PR TITLE
Bugfix/connect app to backend

### DIFF
--- a/.env
+++ b/.env
@@ -1,1 +1,1 @@
-NEXT_PUBLIC_API_BASE_URL=http://model-service:8080
+NEXT_PUBLIC_API_BASE_URL=model-service:8080

--- a/app/client-page.tsx
+++ b/app/client-page.tsx
@@ -29,7 +29,7 @@ export default function ClientPage({ libVersion }: { libVersion: string }) {
       }
 
       const data = await response.json();
-      setResult(data);
+      setResult(data.prediction);
     } catch (err) {
       setError(err instanceof Error ? err.message : "An error occurred");
     } finally {

--- a/app/client-page.tsx
+++ b/app/client-page.tsx
@@ -14,7 +14,7 @@ export default function ClientPage({ libVersion }: { libVersion: string }) {
     setError(null);
 
     try {
-      const baseUrl = process.env.NEXT_PUBLIC_API_BASE_URL;
+      const baseUrl = '/model-service';
       if (!baseUrl) {
         throw new Error("API base URL is not configured");
       }

--- a/next.config.ts
+++ b/next.config.ts
@@ -4,6 +4,14 @@ const nextConfig: NextConfig = {
   /* config options here */
   output: "standalone",
   reactStrictMode: true,
+  async rewrites() {
+    return [
+      {
+        source: '/model-service/:path*',
+        destination: `http://${process.env.NEXT_PUBLIC_API_BASE_URL}/:path*`,
+      },
+    ]
+  },
 };
 
 export default nextConfig;


### PR DESCRIPTION
Use next.js [rewrites](https://nextjs.org/docs/app/api-reference/config/next-config-js/rewrites) to create a URL proxy.
It will reroute all requests through the next.js server container which can access model-service by its hostname.
Before that, all requests were being sent from the client's browser which couldn't find 'model-service:8080' because it didn't have access to the docker network.