### PR TITLE
Added information to github workflows to target main branch

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -35,7 +35,8 @@ jobs:
           git tag ${{ steps.bump-prerelease.outputs.version }}
 
       - name: Push changes
-        uses: ad-m/github-push-action@v0.6.0
+        uses: ad-m/github-push-action@v0.8.0
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
+          branch: ${{ github.ref }}
           tags: true

--- a/.github/workflows/release-version.yml
+++ b/.github/workflows/release-version.yml
@@ -67,4 +67,5 @@ jobs:
         uses: ad-m/github-push-action@v0.8.0
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
+          branch: ${{ github.ref }}
           tags: true


### PR DESCRIPTION
Default branch for push action workflow was defunct branch `master`. 